### PR TITLE
Fix nullpointer crashes and add a bit of user experience improvements.

### DIFF
--- a/Deceive/Deceive.csproj
+++ b/Deceive/Deceive.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -35,7 +35,7 @@ namespace Deceive
 
         private void SetupMenuItems()
         {
-            var aboutMenuItem = new MenuItem("Deceive v1.3.0");
+            var aboutMenuItem = new MenuItem("Deceive v1.3.1");
             aboutMenuItem.Enabled = false;
 
             var enabledMenuItem = new MenuItem("Enabled", (a, e) =>

--- a/Deceive/Program.cs
+++ b/Deceive/Program.cs
@@ -41,6 +41,8 @@ namespace Deceive
             // We are supposed to launch league, so if it's already running something is going wrong.
             if (Utils.IsLCURunning())
             {
+                Utils.InitPathWithRunningLCU();
+
                 var result = MessageBox.Show(
                     "League is currently running. In order to mask your online status, League needs to be started by Deceive. Do you want Deceive to stop League, so that it can restart it with the proper configuration?",
                     "Deceive",
@@ -60,8 +62,11 @@ namespace Deceive
 
             // Step 2: Find original system.yaml, patch our localhost proxy in, and save it somewhere.
             // At the same time, also parse the system.yaml to get the original chat server locations.
-            var leaguePath = Utils.GetLCUPath();
-            var contents = File.ReadAllText(Utils.GetSystemYamlPath());
+            var sysYamlPath = Utils.GetSystemYamlPath();
+            if (sysYamlPath == null) // If this is null, it means we canceled something that required manual user input. Just exit.
+                return;
+
+            var contents = File.ReadAllText(sysYamlPath);
 
             // Load the stream
             var yaml = new YamlStream();
@@ -75,6 +80,7 @@ namespace Deceive
             // This is because league segfaults if you give it an override path with unicode characters,
             // such as some users with a special character in their Windows user name may have.
             // We put it in the Config folder since the new patcher will nuke any non-league files in the install root.
+            var leaguePath = Utils.GetLCUPath();
             var yamlPath = Path.Combine(Path.GetDirectoryName(leaguePath), "Config", "deceive-system.yaml");
             File.WriteAllText(yamlPath, contents);
 

--- a/Deceive/Properties/AssemblyInfo.cs
+++ b/Deceive/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Deceive")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("HP Inc.")]
+[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Deceive")]
-[assembly: AssemblyCopyright("Copyright © HP Inc. 2017")]
+[assembly: AssemblyCopyright("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -83,14 +83,23 @@ namespace Deceive
         {
             string path;
             string configPath = Path.Combine(DATA_DIR, "lcuPath");
+            string initialDirectory = "C:\\Riot Games\\League of Legends";
 
-            if (File.Exists(configPath))
-                path = File.ReadAllText(configPath);
+            if (File.Exists(CONFIG_PATH))
+                path = File.ReadAllText(CONFIG_PATH);
             else
             {
-                path = Registry.GetValue("HKEY_CURRENT_USER\\Software\\Riot Games\\RADS", "LocalRootFolder", "").ToString();
-                // Remove "RADS" from the string's end
-                path = path.Remove(path.Length - 4) + "LeagueClient.exe";
+                object registry = Registry.GetValue("HKEY_CURRENT_USER\\Software\\Riot Games\\RADS", "LocalRootFolder", "");
+                if (registry == null)
+                {
+                    path = initialDirectory;
+                }
+                else
+                {
+                    path = registry.ToString();
+                    // Remove "RADS" from the string's end
+                    path = path.Remove(path.Length - 4) + "LeagueClient.exe";
+                }
             }
 
             while (!IsValidLCUPath(path))
@@ -106,7 +115,7 @@ namespace Deceive
                 // Ask for new path.
                 CommonOpenFileDialog dialog = new CommonOpenFileDialog();
                 dialog.Title = "Select LeagueClient.exe location.";
-                dialog.InitialDirectory = "C:\\Riot Games\\League of Legends";
+                dialog.InitialDirectory = initialDirectory;
                 dialog.EnsureFileExists = true;
                 dialog.EnsurePathExists = true;
                 dialog.DefaultFileName = "LeagueClient";

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Dialogs;
+using System.Management;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -12,6 +13,9 @@ namespace Deceive
     class Utils
     {
         public static readonly string DATA_DIR = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Deceive");
+        private static Regex AUTH_TOKEN_REGEX = new Regex("\"--remoting-auth-token=(.+?)\"");
+        private static Regex PORT_REGEX = new Regex("\"--app-port=(\\d+?)\"");
+        private static string CONFIG_PATH = Path.Combine(DATA_DIR, "lcuPath");
 
         static Utils()
         {
@@ -43,6 +47,9 @@ namespace Deceive
         public static string GetSystemYamlPath()
         {
             var league = GetLCUPath();
+            if (league == null)
+                return null;
+
             var releases = Path.GetDirectoryName(league) + "/RADS/projects/league_client/releases";
 
             // Old patcher has the system.yaml in RADS/projects/league_client/releases/<version>/deploy
@@ -82,7 +89,6 @@ namespace Deceive
         public static string GetLCUPath()
         {
             string path;
-            string configPath = Path.Combine(DATA_DIR, "lcuPath");
             string initialDirectory = "C:\\Riot Games\\League of Legends";
 
             if (File.Exists(CONFIG_PATH))
@@ -132,7 +138,7 @@ namespace Deceive
             }
 
             // Store choice so we don't have to ask for it again.
-            File.WriteAllText(configPath, path);
+            File.WriteAllText(CONFIG_PATH, path);
 
             return path;
         }
@@ -156,22 +162,37 @@ namespace Deceive
             }
         }
 
-        // Checks if there is a running LCU instance.
-        public static bool IsLCURunning()
+        private static Process[] GetLeagueProcesses()
         {
             Process[] lcuCandidates = Process.GetProcessesByName("LeagueClient");
             lcuCandidates = lcuCandidates.Concat(Process.GetProcessesByName("LeagueClientUx")).ToArray();
             lcuCandidates = lcuCandidates.Concat(Process.GetProcessesByName("LeagueClientUxRender")).ToArray();
+            return lcuCandidates;
+        }
 
-            return lcuCandidates.Length > 0;
+        public static void InitPathWithRunningLCU()
+        {
+            // Find the LeagueClientUx process.
+            foreach (var p in GetLeagueProcesses())
+            {
+                if (!IsValidLCUPath(p.MainModule.FileName))
+                    continue;
+
+                File.WriteAllText(CONFIG_PATH, p.MainModule.FileName);
+                return;
+            }
+        }
+
+        // Checks if there is a running LCU instance.
+        public static bool IsLCURunning()
+        {
+            return GetLeagueProcesses().Length > 0;
         }
 
         // Kills the running LCU instance, if applicable.
         public static void KillLCU()
         {
-            Process[] lcuCandidates = Process.GetProcessesByName("LeagueClient");
-            lcuCandidates = lcuCandidates.Concat(Process.GetProcessesByName("LeagueClientUx")).ToArray();
-            lcuCandidates = lcuCandidates.Concat(Process.GetProcessesByName("LeagueClientUxRender")).ToArray();
+            Process[] lcuCandidates = GetLeagueProcesses();
 
             foreach (Process lcu in lcuCandidates)
             {


### PR DESCRIPTION
If the user runs the app for the first time while League is open, we steal the path from the running process.
A null registry entry now no longer crashes on a null pointer.
If the user cancels, no longer do we crash on a null pointer. 