### PR TITLE
lets LCU show masked availability + fixed wrong presence for 'online'

### DIFF
--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -192,6 +192,7 @@ namespace Deceive
                         status.LoadXml(presence["status"].InnerText);
                         status["body"]["statusMsg"].InnerText = "";
                         status["body"]["gameStatus"].InnerText = "outOfGame";
+                        if (status["body"].InnerXml.Contains("pty")) status["body"].RemoveChild(status["body"]["pty"]);
 
                         presence["status"].InnerText = status.OuterXml;
                     }

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -60,7 +60,7 @@ namespace Deceive
             var enabledMenuItem = new MenuItem("Enabled", (a, e) =>
             {
                 enabled = !enabled;
-                UpdateStatus(enabled ? status : "online");
+                UpdateStatus(enabled ? status : "chat");
                 SetupMenuItems();
             });
             enabledMenuItem.Checked = enabled;

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -46,7 +46,7 @@ namespace Deceive
                 catch
                 {
                     // LCU is not ready yet. Wait for a bit.
-                    await Task.Delay(5000);
+                    await Task.Delay(3000);
                 }
             }
         }
@@ -71,6 +71,7 @@ namespace Deceive
             var offlineStatus = new MenuItem("Offline", (a, e) =>
             {
                 UpdateStatus(status = "offline");
+                enabled = true;
                 SetupMenuItems();
             })
             {
@@ -80,6 +81,7 @@ namespace Deceive
             var mobileStatus = new MenuItem("Mobile", (a, e) =>
             {
                 UpdateStatus(status = "mobile");
+                enabled = true;
                 SetupMenuItems();
             })
             {

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -186,7 +186,7 @@ namespace Deceive
                     this.lastPresence = content;
                     presence["show"].InnerText = targetStatus;
 
-                    if (targetStatus != "online")
+                    if (targetStatus != "chat")
                     {
                         var status = new XmlDocument();
                         status.LoadXml(presence["status"].InnerText);

--- a/Deceive/Program.cs
+++ b/Deceive/Program.cs
@@ -58,7 +58,7 @@ namespace Deceive
             // Step 1: Open a port for our proxy, so we can patch the port number into the system yaml.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
-            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
             // Step 2: Find original system.yaml, patch our localhost proxy in, and save it somewhere.
             // At the same time, also parse the system.yaml to get the original chat server locations.
@@ -95,7 +95,8 @@ namespace Deceive
                     FileName = riotClientPath,
                     Arguments = "--priority-launch-pid=12345 --priority-launch-path=\"" + leaguePath + "\" -- --system-yaml-override=\"" + yamlPath + "\"",
                 };
-            } else
+            }
+            else
             {
                 startArgs = new ProcessStartInfo
                 {

--- a/Deceive/Properties/AssemblyInfo.cs
+++ b/Deceive/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.1.0")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]


### PR DESCRIPTION
Copying my code comment: 
```        
/*
* sends our masked availability to LCU for display to local player, instead of showing normal status
* LCU will only display availability, so still shows 'Creating Normal Game' or 'In Game',
* but only locally, since Deceive masks whole presence with 'gameStatus' as 'outOfGame'.
* Passing this/whole presence to LCU doesn't make a difference as LCU just overrides it.
*/
```
![image](https://user-images.githubusercontent.com/17106472/65834061-775de900-e2d7-11e9-9bde-1fb1b4f70d23.png)


I think having it like this is still better than just 'online', since you can see that Deceive is working (or doing something)...
![image](https://user-images.githubusercontent.com/17106472/65833971-94de8300-e2d6-11e9-9466-9df8e354a2d9.png)

Changed presence to be like LCU does it:
Comparison of `<show>online</show>` and `<show>chat</show>`
![comparison](https://user-images.githubusercontent.com/17106472/65834054-690fcd00-e2d7-11e9-9939-17372c13082d.png)
