### PR TITLE
Show Deceive version in popups for easier bug reports

### DIFF
--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
+using Deceive.Properties;
 
 namespace Deceive
 {
@@ -23,9 +24,9 @@ namespace Deceive
         {
             trayIcon = new NotifyIcon()
             {
-                Icon = Properties.Resources.deceive,
+                Icon = Resources.deceive,
                 Visible = true,
-                BalloonTipTitle = "Deceive",
+                BalloonTipTitle = Resources.DeceiveTitle,
                 BalloonTipText = "Deceive is currently masking your status. Right-Click the tray icon for more options."
             };
             trayIcon.ShowBalloonTip(5000);
@@ -53,7 +54,7 @@ namespace Deceive
 
         private void SetupMenuItems()
         {
-            var aboutMenuItem = new MenuItem("Deceive v1.5.0")
+            var aboutMenuItem = new MenuItem(Resources.DeceiveTitle)
             {
                 Enabled = false
             };
@@ -94,7 +95,7 @@ namespace Deceive
             {
                 var result = MessageBox.Show(
                     "Are you sure you want to stop Deceive? This will also stop League if it is running.",
-                    "Deceive",
+                    Resources.DeceiveTitle,
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Question,
                     MessageBoxDefaultButton.Button1

--- a/Deceive/Program.cs
+++ b/Deceive/Program.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Deceive.Properties;
 using YamlDotNet.RepresentationModel;
 
 namespace Deceive
@@ -25,7 +26,7 @@ namespace Deceive
                 // Show some kind of message so that Deceive doesn't just disappear.
                 MessageBox.Show(
                     "Deceive encountered an error and couldn't properly initialize itself. Please contact the creator through GitHub (https://github.com/molenzwiebel/deceive) or Discord.\n\n" + ex,
-                    "Deceive",
+                    Resources.DeceiveTitle,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error,
                     MessageBoxDefaultButton.Button1
@@ -45,7 +46,7 @@ namespace Deceive
 
                 var result = MessageBox.Show(
                     "League is currently running. In order to mask your online status, League needs to be started by Deceive. Do you want Deceive to stop League, so that it can restart it with the proper configuration?",
-                    "Deceive",
+                    Resources.DeceiveTitle,
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Question,
                     MessageBoxDefaultButton.Button1

--- a/Deceive/Properties/Resources.Designer.cs
+++ b/Deceive/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Deceive.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -77,6 +77,15 @@ namespace Deceive.Properties {
             get {
                 object obj = ResourceManager.GetObject("deceive", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deceive v1.5.0.
+        /// </summary>
+        internal static string DeceiveTitle {
+            get {
+                return ResourceManager.GetString("DeceiveTitle", resourceCulture);
             }
         }
     }

--- a/Deceive/Properties/Resources.resx
+++ b/Deceive/Properties/Resources.resx
@@ -124,4 +124,7 @@
   <data name="deceive" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\deceive.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="DeceiveTitle" xml:space="preserve">
+    <value>Deceive v1.5.0</value>
+  </data>
 </root>

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Deceive.Properties;
 
 namespace Deceive
 {
@@ -86,7 +87,7 @@ namespace Deceive
                 // Notify that the path is invalid.
                 MessageBox.Show(
                     "Could not find the League client at " + path + ". Please select the location of 'LeagueClient.exe' manually.",
-                    "LCU not found",
+                    Resources.DeceiveTitle,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Exclamation
                 );
@@ -159,7 +160,7 @@ namespace Deceive
                 {
                     var result = MessageBox.Show(
                         "League is currently running in admin mode. In order to proceed Deceive also needs to be elevated. Do you want Deceive to restart in admin mode?",
-                        "Deceive",
+                        Resources.DeceiveTitle,
                         MessageBoxButtons.YesNo,
                         MessageBoxIcon.Question,
                         MessageBoxDefaultButton.Button1


### PR DESCRIPTION
Showing the current Deceive version in all popups makes it easier to identify the version somebody is using in screenshot bug reports.