### PR TITLE
Use rc_default/rc_live/rc_beta to find Riot Client

### DIFF
--- a/Deceive/Properties/AssemblyInfo.cs
+++ b/Deceive/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.5.1.0")]
+[assembly: AssemblyFileVersion("1.5.1.0")]

--- a/Deceive/Properties/Resources.Designer.cs
+++ b/Deceive/Properties/Resources.Designer.cs
@@ -81,7 +81,7 @@ namespace Deceive.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deceive v1.5.0.
+        ///   Looks up a localized string similar to Deceive v1.5.1.
         /// </summary>
         internal static string DeceiveTitle {
             get {

--- a/Deceive/Properties/Resources.resx
+++ b/Deceive/Properties/Resources.resx
@@ -125,6 +125,6 @@
     <value>..\Resources\deceive.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DeceiveTitle" xml:space="preserve">
-    <value>Deceive v1.5.0</value>
+    <value>Deceive v1.5.1</value>
   </data>
 </root>

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -213,7 +213,7 @@ namespace Deceive
             }
         }
 
-        // Checks if the current client has a Riot Client configuration,
+        // Checks for any installed Riot Client configuration,
         // and returns the path of the client if it does. Else, returns null.
         public static string GetRiotClientPath()
         {
@@ -221,24 +221,17 @@ namespace Deceive
             var installPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Riot Games/RiotClientInstalls.json");
             if (!File.Exists(installPath)) return null;
 
-            // Ensure it has a list of installed clients.
             JsonObject data = (JsonObject)SimpleJson.DeserializeObject(File.ReadAllText(installPath));
-            if (data["associated_client"] == null || !(data["associated_client"] is JsonObject)) return null;
+            String[] rcPaths = {};
+            if (data.ContainsKey("rc_default")) rcPaths.Append(data["rc_default"]);
+            if (data.ContainsKey("rc_live")) rcPaths.Append(data["rc_live"]);
+            if (data.ContainsKey("rc_beta")) rcPaths.Append(data["rc_beta"]);
 
-            // Find the directory of the client we're attempting to launch.
-            var baseDir = Path.GetDirectoryName(GetLCUPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-            // For every entry, see if it matches after normalization.
-            // We need to normalize since the client is inconsistent with direction of slashes and trailing slashes.
-            foreach (var entry in (JsonObject)data["associated_client"])
+            foreach (var entry in rcPaths)
             {
-                var normalizedPath = Path.GetFullPath(entry.Key).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-                if (normalizedPath == baseDir && ((string)entry.Value).Contains("RiotClientServices.exe"))
-                {
-                    return (string)entry.Value;
-                }
+                if (File.Exists(entry)) return entry;
             }
+            
             return null;
         }
 

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -222,7 +222,7 @@ namespace Deceive
             if (!File.Exists(installPath)) return null;
 
             JsonObject data = (JsonObject)SimpleJson.DeserializeObject(File.ReadAllText(installPath));
-            String[] rcPaths = {};
+            string[] rcPaths = {};
             if (data.ContainsKey("rc_default")) rcPaths.Append(data["rc_default"]);
             if (data.ContainsKey("rc_live")) rcPaths.Append(data["rc_live"]);
             if (data.ContainsKey("rc_beta")) rcPaths.Append(data["rc_beta"]);


### PR DESCRIPTION
Check for these entries in RC json config file instead of checking the path for a matching LCU installation, since most likely only a single Riot Client will exist for all current and future games.