### PR TITLE
Overlay improvements

### DIFF
--- a/Deceive/Deceive.csproj
+++ b/Deceive/Deceive.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props')" />
+  <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -42,12 +42,12 @@
     <ApplicationIcon>Resources\deceive.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=3.3.3.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
-      <HintPath>..\packages\Costura.Fody.3.3.3\lib\net40\Costura.dll</HintPath>
+    <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
+      <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EmbedIO, Version=3.1.4.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e">
-      <HintPath>..\packages\EmbedIO.3.1.4\lib\netstandard2.0\EmbedIO.dll</HintPath>
+    <Reference Include="EmbedIO, Version=3.3.3.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e">
+      <HintPath>..\packages\EmbedIO.3.3.3\lib\netstandard2.0\EmbedIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.2.0, Culture=neutral, PublicKeyToken=null">
@@ -57,16 +57,21 @@
     <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Swan.Lite, Version=2.4.3.0, Culture=neutral, PublicKeyToken=30c707c872729fff">
-      <HintPath>..\packages\Unosquare.Swan.Lite.2.4.3\lib\netstandard2.0\Swan.Lite.dll</HintPath>
+    <Reference Include="Swan.Lite, Version=2.6.1.0, Culture=neutral, PublicKeyToken=30c707c872729fff">
+      <HintPath>..\packages\Unosquare.Swan.Lite.2.6.1\lib\net461\Swan.Lite.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
@@ -79,7 +84,7 @@
     <Reference Include="netstandard" />
     <Reference Include="WindowsBase" />
     <Reference Include="YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e">
-      <HintPath>..\packages\YamlDotNet.8.0.0\lib\net45\YamlDotNet.dll</HintPath>
+      <HintPath>..\packages\YamlDotNet.8.1.0\lib\net45\YamlDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -118,12 +123,12 @@
     <EmbeddedResource Include="Resources\deceive.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.4.0.2\build\Fody.targets" Condition="Exists('..\packages\Fody.4.0.2\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.6.1.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.1.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.4.0.2\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.4.0.2\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.1.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.1.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
   </Target>
 </Project>

--- a/Deceive/LCUOverlay.cs
+++ b/Deceive/LCUOverlay.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Drawing;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;

--- a/Deceive/packages.config
+++ b/Deceive/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="3.3.3" targetFramework="net48" />
-  <package id="EmbedIO" version="3.1.4" targetFramework="net461" />
-  <package id="Fody" version="4.0.2" targetFramework="net48" developmentDependency="true" />
+  <package id="Costura.Fody" version="4.1.0" targetFramework="net48" />
+  <package id="EmbedIO" version="3.3.3" targetFramework="net48" />
+  <package id="Fody" version="6.1.0" targetFramework="net48" developmentDependency="true" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net461" />
-  <package id="Unosquare.Swan.Lite" version="2.4.3" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="Unosquare.Swan.Lite" version="2.6.1" targetFramework="net48" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net461" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net461" />
-  <package id="YamlDotNet" version="8.0.0" targetFramework="net461" />
+  <package id="YamlDotNet" version="8.1.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
- more window listeners (minimize end, alt+tab end)
- 'fix' or workaround crash on showing overlay in TargetMoved method
- fix initial position not being set by FocusChanged when first launched, therefore not visible at first
  - somehow inital position/size still incorrect, but fixes itself fast, not sure why.. probably uses default RenderSize
- ignore mouse location changes