### PR TITLE
Fix player unable to join MUC lobby & Add option to toggle overlay and disable MUC

### DIFF
--- a/Deceive/ConfigProxy.cs
+++ b/Deceive/ConfigProxy.cs
@@ -41,7 +41,7 @@ namespace Deceive
 
             // Start a web server that sends everything to ProxyAndRewriteResponse
             var server = new WebServer(o => o
-                    .WithUrlPrefix("http://localhost:" + port)
+                    .WithUrlPrefix("http://127.0.0.1:" + port)
                     .WithMode(HttpListenerMode.EmbedIO))
                 .WithModule(new ActionModule("/", HttpVerbs.Get,
                     ctx => ProxyAndRewriteResponse(configUrl, chatPort, ctx)));

--- a/Deceive/ConfigProxy.cs
+++ b/Deceive/ConfigProxy.cs
@@ -82,6 +82,7 @@ namespace Deceive
                 var result = await _client.SendAsync(message);
                 var content = await result.Content.ReadAsStringAsync();
                 var modifiedContent = content;
+                Debug.WriteLine(content);
 
                 try
                 {

--- a/Deceive/Deceive.csproj
+++ b/Deceive/Deceive.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props')" />
+  <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,8 +45,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=3.3.3.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
-      <HintPath>..\packages\Costura.Fody.3.3.3\lib\net40\Costura.dll</HintPath>
+    <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d">
+      <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EmbedIO, Version=3.3.3.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e">
@@ -116,12 +116,12 @@
     <EmbeddedResource Include="Resources\deceive.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.4.0.2\build\Fody.targets" Condition="Exists('..\packages\Fody.4.0.2\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.4.0.2\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.4.0.2\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.3.3.3\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.1.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.1.0\build\Fody.targets'))" />
   </Target>
+  <Import Project="..\packages\Fody.6.1.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.1.0\build\Fody.targets')" />
 </Project>

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -17,6 +17,7 @@ namespace Deceive
         private bool _enabled = true;
         private string _status;
         private readonly string _statusFile = Path.Combine(Utils.DataDir, "status");
+        private bool _connectToMuc = true;
         
         private LCUOverlay _overlay = null;
         private WindowFollower _follower = null;
@@ -87,6 +88,15 @@ namespace Deceive
             {
                 Checked = _overlay != null
             };
+            
+            var mucMenuItem = new MenuItem("Lobby Chat enabled", (a, e) =>
+            {
+                _connectToMuc = !_connectToMuc;
+                UpdateUI();
+            })
+            {
+                Checked = _connectToMuc
+            };
 
             var offlineStatus = new MenuItem("Offline", (a, e) =>
             {
@@ -127,7 +137,7 @@ namespace Deceive
                 Application.Exit();
             });
 
-            _trayIcon.ContextMenu = new ContextMenu(new[] {aboutMenuItem, enabledMenuItem, overlayMenuItem, typeMenuItem, quitMenuItem});
+            _trayIcon.ContextMenu = new ContextMenu(new[] {aboutMenuItem, enabledMenuItem, typeMenuItem, overlayMenuItem, mucMenuItem, quitMenuItem});
             _overlay?.UpdateStatus(_status, _enabled);
         }
 
@@ -210,8 +220,12 @@ namespace Deceive
                 
                 foreach (var presence in xml.Root.Elements())
                 {
-                    if (presence.Name != "presence") continue; 
-                    if (presence.Attribute("to") != null) continue;
+                    if (presence.Name != "presence") continue;
+                    if (presence.Attribute("to") != null)
+                    {
+                        if (_connectToMuc) continue;
+                        presence.Remove();
+                    };
                     
                     presence.Element("show").Value = targetStatus;
 

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -71,7 +71,7 @@ namespace Deceive
                 Checked = _enabled
             };
             
-            var overlayMenuItem = new MenuItem("Status Overlay enabled", (a, e) =>
+            var overlayMenuItem = new MenuItem("Show status overlay", (a, e) =>
             {
                 if (_overlay == null)
                 {
@@ -89,7 +89,7 @@ namespace Deceive
                 Checked = _overlay != null
             };
             
-            var mucMenuItem = new MenuItem("Lobby Chat enabled", (a, e) =>
+            var mucMenuItem = new MenuItem("Enable lobby chat", (a, e) =>
             {
                 _connectToMuc = !_connectToMuc;
                 UpdateUI();

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -37,18 +37,20 @@ namespace Deceive
             _trayIcon.ShowBalloonTip(5000);
 
             // Create overlay and start following the LCU with it.
-            if (isLeague)
-            {
-                var process = Process.GetProcessesByName("LeagueClientUx").First();
-            
-                _overlay = new LCUOverlay();
-                _overlay.Show();
-                _follower = new WindowFollower(_overlay, process);
-                _follower.StartFollowing();
-            }
-            
+            if (isLeague) CreateOverlay();
+
             LoadStatus();
             UpdateUI();
+        }
+
+        private void CreateOverlay()
+        {
+            var process = Process.GetProcessesByName("LeagueClientUx").First();
+
+            _overlay = new LCUOverlay();
+            _overlay.Show();
+            _follower = new WindowFollower(_overlay, process);
+            _follower.StartFollowing();
         }
 
         private void UpdateUI()
@@ -66,6 +68,24 @@ namespace Deceive
             })
             {
                 Checked = _enabled
+            };
+            
+            var overlayMenuItem = new MenuItem("Status Overlay enabled", (a, e) =>
+            {
+                if (_overlay == null)
+                {
+                    CreateOverlay();
+                }
+                else
+                {
+                    _follower.Dispose();
+                    _overlay.Close();
+                    _overlay = null;
+                }
+                UpdateUI();
+            })
+            {
+                Checked = _overlay != null
             };
 
             var offlineStatus = new MenuItem("Offline", (a, e) =>
@@ -107,7 +127,7 @@ namespace Deceive
                 Application.Exit();
             });
 
-            _trayIcon.ContextMenu = new ContextMenu(new[] {aboutMenuItem, enabledMenuItem, typeMenuItem, quitMenuItem});
+            _trayIcon.ContextMenu = new ContextMenu(new[] {aboutMenuItem, enabledMenuItem, overlayMenuItem, typeMenuItem, quitMenuItem});
             _overlay?.UpdateStatus(_status, _enabled);
         }
 

--- a/Deceive/Properties/AssemblyInfo.cs
+++ b/Deceive/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]

--- a/Deceive/Properties/Resources.Designer.cs
+++ b/Deceive/Properties/Resources.Designer.cs
@@ -81,7 +81,7 @@ namespace Deceive.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to v1.7.0.
+        ///   Looks up a localized string similar to v1.7.1.
         /// </summary>
         internal static string DeceiveVersion {
             get {

--- a/Deceive/Properties/Resources.resx
+++ b/Deceive/Properties/Resources.resx
@@ -125,6 +125,6 @@
     <value>..\Resources\deceive.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DeceiveVersion" xml:space="preserve">
-    <value>v1.7.0</value>
+    <value>v1.7.1</value>
   </data>
 </root>

--- a/Deceive/StartupHandler.cs
+++ b/Deceive/StartupHandler.cs
@@ -90,7 +90,7 @@ namespace Deceive
             var startArgs = new ProcessStartInfo
             {
                 FileName = riotClientPath,
-                Arguments = "--client-config-url=\"http://localhost:" + proxyServer.ConfigPort + "\" --launch-product=" + game + " --launch-patchline=live"
+                Arguments = "--client-config-url=\"http://127.0.0.1:" + proxyServer.ConfigPort + "\" --launch-product=" + game + " --launch-patchline=live"
             };
             Process.Start(startArgs);
             

--- a/Deceive/packages.config
+++ b/Deceive/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="3.3.3" targetFramework="net48" />
+  <package id="Costura.Fody" version="4.1.0" targetFramework="net48" />
   <package id="EmbedIO" version="3.3.3" targetFramework="net48" />
-  <package id="Fody" version="4.0.2" targetFramework="net48" developmentDependency="true" />
+  <package id="Fody" version="6.1.0" targetFramework="net48" developmentDependency="true" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="Unosquare.Swan.Lite" version="2.6.1" targetFramework="net48" />


### PR DESCRIPTION
Dupe of #41, but fixed old commits reappearing by using new branch and replaying commits.
Renamed context menu items as commented in #41 as well.
https://github.com/aPinat/Deceive/releases/tag/20200217.1

---

`XElement.ToString()` probably messed up JSON presence encoding/escaping...
XmlWriter checks per written fragment (`ConformanceLevel.Fragment`), that XML string is written correctly and therefore doesn't complain about duped root elements.

CI release: https://github.com/aPinat/Deceive/releases/tag/20200211.1

-- Commit Message --
Using a real XmlWriter fixes player unable to join MUC lobby
Bumped version to 1.7.1
Added some Debug output, changed Console to Trace for release mode as we have no console