### PR TITLE
Fix update prompt showing for newer Deceive builds

### DIFF
--- a/Deceive/Properties/Resources.Designer.cs
+++ b/Deceive/Properties/Resources.Designer.cs
@@ -79,14 +79,5 @@ namespace Deceive.Properties {
                 return ((System.Drawing.Icon)(obj));
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to v1.7.0.
-        /// </summary>
-        internal static string DeceiveVersion {
-            get {
-                return ResourceManager.GetString("DeceiveVersion", resourceCulture);
-            }
-        }
     }
 }

--- a/Deceive/Properties/Resources.resx
+++ b/Deceive/Properties/Resources.resx
@@ -124,7 +124,4 @@
   <data name="deceive" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\deceive.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="DeceiveVersion" xml:space="preserve">
-    <value>v1.7.0</value>
-  </data>
 </root>

--- a/Deceive/StartupHandler.cs
+++ b/Deceive/StartupHandler.cs
@@ -13,7 +13,7 @@ namespace Deceive
 {
     internal static class StartupHandler
     {
-        internal static string DeceiveTitle => "Deceive " + Resources.DeceiveVersion;
+        internal static string DeceiveTitle => "Deceive " + Utils.DeceiveVersion;
 
         [STAThread]
         private static void Main(string[] args)


### PR DESCRIPTION
Remove version string from Resources and get from Assembly, so we don't need to change in 2 places.