### PR TITLE
Fix update prompt showing again after cancel

### DIFF
--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -57,7 +57,7 @@ internal static class Utils
             var latestShownVersion = Persistence.GetPromptedUpdateVersion();
 
             // If we have, return.
-            if (string.IsNullOrEmpty(latestShownVersion) && latestShownVersion == latestVersion)
+            if (!string.IsNullOrEmpty(latestShownVersion) && latestShownVersion == latestVersion)
                 return;
 
             // Show a message and record the latest shown.


### PR DESCRIPTION
Stops the update Deceive message box from popping up again after hitting cancel. Small fix to condition check.