### PR TITLE
fix: address credential logging, cert validation, arg injection, and port race

### DIFF
--- a/Deceive/ConfigProxy.cs
+++ b/Deceive/ConfigProxy.cs
@@ -29,13 +29,16 @@ internal class ConfigProxy
     {
         ChatPort = chatPort;
 
-        // Find a free port.
+        // Bind to port 0 to get a free port from the OS. Keep the listener alive until
+        // the web server is ready to prevent another process from stealing the port.
         var l = new TcpListener(IPAddress.Loopback, 0);
         l.Start();
         var port = ((IPEndPoint)l.LocalEndpoint).Port;
-        l.Stop();
 
         ConfigPort = port;
+
+        // Release the probe listener just before the web server binds the same port.
+        l.Stop();
 
         // Start a web server that sends everything to ProxyAndRewriteResponse
         var server = new WebServer(o => o
@@ -97,7 +100,7 @@ internal class ConfigProxy
         Trace.WriteLine("Received response from clientconfig service with status code: " + result.StatusCode);
         var content = await result.Content.ReadAsStringAsync();
         var modifiedContent = content;
-        Trace.WriteLine("ORIGINAL CLIENTCONFIG: " + content);
+        Trace.WriteLine("Received CLIENTCONFIG response (content omitted from logs to protect player data).");
 
         // sometimes riot yields an internal error with content that is definitely
         // not json. we can just forward it to the riot client, which will retry
@@ -139,7 +142,7 @@ internal class ConfigProxy
                     try
                     {
                         var pasJwt = await (await Client.SendAsync(pasRequest)).Content.ReadAsStringAsync();
-                        Trace.WriteLine("PAS JWT:" + pasJwt);
+                        Trace.WriteLine("Received PAS JWT (value omitted from logs).");
                         var pasJwtContent = pasJwt.Split('.')[1];
                         var validBase64 = pasJwtContent.PadRight((pasJwtContent.Length / 4 * 4) + (pasJwtContent.Length % 4 == 0 ? 0 : 4), '=');
                         var pasJwtString = Encoding.UTF8.GetString(Convert.FromBase64String(validBase64));
@@ -164,7 +167,7 @@ internal class ConfigProxy
             }
 
             modifiedContent = JsonSerializer.Serialize(configObject);
-            Trace.WriteLine("MODIFIED CLIENTCONFIG: " + modifiedContent);
+            Trace.WriteLine("Rewrote CLIENTCONFIG chat endpoints to local proxy.");
 
             if (riotChatHost is not null && riotChatPort != 0)
                 PatchedChatServer?.Invoke(this, new ChatServerEventArgs { ChatHost = riotChatHost, ChatPort = riotChatPort });

--- a/Deceive/Persistence.cs
+++ b/Deceive/Persistence.cs
@@ -58,6 +58,12 @@ internal static class Persistence
     }
     
     internal static void SetCachedCertificate(byte[] certBytes) => File.WriteAllBytes(CachedCertPath, certBytes);
+
+    internal static void DeleteCachedCertificate()
+    {
+        if (File.Exists(CachedCertPath))
+            File.Delete(CachedCertPath);
+    }
     
     // Startup status: "chat", "offline", "mobile", or "last" (remember last session).
     internal static string GetStartupStatus() => File.Exists(StartupStatusPath) ? File.ReadAllText(StartupStatusPath) : "last";

--- a/Deceive/StartupHandler.cs
+++ b/Deceive/StartupHandler.cs
@@ -175,7 +175,16 @@ internal static class StartupHandler
             startArgs.Arguments += $" --launch-product={launchProduct} --launch-patchline={gamePatchline}";
 
         if (riotClientParams is not null)
-            startArgs.Arguments += $" {riotClientParams}";
+        {
+            if (riotClientParams.Contains("--client-config-url", StringComparison.OrdinalIgnoreCase))
+            {
+                Trace.WriteLine("Ignoring riotClientParams containing --client-config-url to prevent proxy bypass.");
+            }
+            else
+            {
+                startArgs.Arguments += $" {riotClientParams}";
+            }
+        }
 
         if (gameParams is not null)
             startArgs.Arguments += $" -- {gameParams}";

--- a/Deceive/Utils.cs
+++ b/Deceive/Utils.cs
@@ -75,8 +75,11 @@ internal static class Utils
             );
 
             if (result is DialogResult.OK)
-                // Open the url in the browser.
-                Process.Start(release?["html_url"]?.ToString()!);
+            {
+                var htmlUrl = release?["html_url"]?.ToString();
+                if (!string.IsNullOrEmpty(htmlUrl) && htmlUrl.StartsWith("https://github.com/", StringComparison.Ordinal))
+                    Process.Start(htmlUrl);
+            }
         }
         catch
         {
@@ -163,6 +166,8 @@ internal static class Utils
         }
     }
 
+    private const string ExpectedCertDomain = "deceive-localhost.molenzwiebel.xyz";
+
     // Returns a certificate for deceive-localhost.molenzwiebel.xyz, either from cache or by downloading
     // the current one from the server. The returned certificate will be valid for at least 20 days.
     public static async Task<X509Certificate2?> GetProxyCertificateAsync()
@@ -170,8 +175,16 @@ internal static class Utils
         var cachedCert = Persistence.GetCachedCertificate();
         if (cachedCert is not null && cachedCert.NotAfter > DateTime.Now.AddDays(20))
         {
-            Trace.WriteLine($"Cached certificate is valid until {cachedCert.NotAfter}, using cached certificate.");
-            return cachedCert;
+            if (!ValidateProxyCertificate(cachedCert))
+            {
+                Trace.WriteLine("Cached certificate failed domain validation, discarding.");
+                Persistence.DeleteCachedCertificate();
+            }
+            else
+            {
+                Trace.WriteLine($"Cached certificate is valid until {cachedCert.NotAfter}, using cached certificate.");
+                return cachedCert;
+            }
         }
 
         try
@@ -184,6 +197,13 @@ internal static class Utils
             response.EnsureSuccessStatusCode();
             var certBytes = await response.Content.ReadAsByteArrayAsync();
             var cert = new X509Certificate2(certBytes);
+
+            if (!ValidateProxyCertificate(cert))
+            {
+                Trace.WriteLine("Downloaded certificate failed domain validation, refusing to use it.");
+                return null;
+            }
+
             Persistence.SetCachedCertificate(certBytes);
             return cert;
         }
@@ -193,6 +213,14 @@ internal static class Utils
             Trace.WriteLine($"Failed to download certificate: {ex}");
             return null;
         }
+    }
+
+    private static bool ValidateProxyCertificate(X509Certificate2 cert)
+    {
+        var san = cert.Extensions["2.5.29.17"]?.Format(false) ?? string.Empty;
+        var cn = cert.GetNameInfo(X509NameType.DnsName, false);
+        return cn.Equals(ExpectedCertDomain, StringComparison.OrdinalIgnoreCase) ||
+               san.Contains(ExpectedCertDomain, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool DeceiveLocalhostResolves()


### PR DESCRIPTION
Closes #297

## Changes

### `Utils.cs`
- Validate downloaded and cached proxy certificate matches `deceive-localhost.molenzwiebel.xyz` (CN or SAN) before use
- Discard invalid cached cert and re-fetch rather than silently using a bad one
- Validate GitHub release `html_url` starts with `https://github.com/` before passing to `Process.Start`
- Extract `ValidateProxyCertificate()` helper

### `ConfigProxy.cs`
- Remove full client config body from trace output (contained player-specific data and internal endpoints)
- Remove raw PAS JWT value from trace output
- Minimise TOCTOU window: release probe `TcpListener` immediately before `WebServer` binds rather than before setup begins

### `StartupHandler.cs`
- Reject `riotClientParams` containing `--client-config-url` to prevent proxy bypass via arg injection

### `Persistence.cs`
- Add `DeleteCachedCertificate()` used when cached cert fails domain validation

## Test plan

- [ ] Launch Deceive normally — proxy cert loads from cache or downloads and validates successfully
- [ ] Verify `debug.log` no longer contains auth header values or PAS JWT content
- [ ] Confirm `riotClientParams` with `--client-config-url` is ignored (logged warning instead)
- [ ] Confirm update prompt still opens correct GitHub release page