### PR TITLE
Add friend status change notifications

### DIFF
--- a/Deceive/FriendNotificationsForm.cs
+++ b/Deceive/FriendNotificationsForm.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using Deceive.Properties;
+
+namespace Deceive;
+
+// Modal window used to configure friend status notifications. A dedicated, searchable, scrollable
+// window is used instead of a tray submenu because a roster can hold hundreds of friends.
+internal sealed class FriendNotificationsForm : Form
+{
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, string lParam);
+
+    private const int EM_SETCUEBANNER = 0x1501;
+
+    // Palette (loosely GitHub-inspired) used for the status dots and text.
+    private static readonly Color TextColor = Color.FromArgb(36, 41, 47);
+    private static readonly Color MutedColor = Color.FromArgb(101, 109, 118);
+    private static readonly Color PanelColor = Color.FromArgb(246, 248, 250);
+    private static readonly Color BorderColor = Color.FromArgb(208, 215, 222);
+
+    // Each known status and the colour of its dot / text.
+    private static readonly (string Status, Color Color)[] StatusPalette =
+    {
+        ("In Game", Color.FromArgb(219, 109, 40)),
+        ("In Champion Select", Color.FromArgb(88, 166, 255)),
+        ("In Queue", Color.FromArgb(88, 166, 255)),
+        ("In Lobby", Color.FromArgb(58, 150, 221)),
+        ("Spectating", Color.FromArgb(163, 113, 247)),
+        ("Online", Color.FromArgb(35, 169, 75)),
+        ("Away", Color.FromArgb(210, 153, 34)),
+        ("Busy", Color.FromArgb(218, 54, 51)),
+        ("Mobile", Color.FromArgb(35, 169, 75)),
+        ("Offline", Color.FromArgb(110, 118, 129)),
+    };
+
+    private sealed class FriendItem
+    {
+        public string RiotId { get; }
+        public string Status { get; }
+        public bool IsOffline => string.Equals(Status, "Offline", StringComparison.OrdinalIgnoreCase);
+
+        public FriendItem(string riotId, string status)
+        {
+            RiotId = riotId;
+            Status = status;
+        }
+    }
+
+    private readonly List<FriendItem> _allFriends;
+    private readonly HashSet<string> _tracked;
+    private readonly Action<string, bool> _setTracked;
+    private readonly Action<bool> _setEnabled;
+
+    private readonly CheckBox _enabledCheckBox;
+    private readonly TextBox _searchBox;
+    private readonly ListView _listView;
+    private readonly ColumnHeader _friendColumn;
+    private readonly ColumnHeader _statusColumn;
+    private readonly ImageList _statusIcons;
+    private readonly Label _countLabel;
+
+    private bool _populating;
+
+    public FriendNotificationsForm(
+        IEnumerable<KeyValuePair<string, string>> friends, // "name#tag" -> current status
+        HashSet<string> tracked,
+        bool enabled,
+        Action<bool> setEnabled,
+        Action<string, bool> setTracked)
+    {
+        _allFriends = friends.Select(friend => new FriendItem(friend.Key, friend.Value)).ToList();
+        _tracked = tracked;
+        _setEnabled = setEnabled;
+        _setTracked = setTracked;
+
+        Text = "Friend Notifications";
+        try
+        {
+            Icon = Resources.DeceiveIcon;
+        }
+        catch
+        {
+            // ignored; the icon is purely cosmetic
+        }
+
+        Font = new Font("Segoe UI", 9.75f);
+        BackColor = Color.White;
+        ForeColor = TextColor;
+        StartPosition = FormStartPosition.CenterScreen;
+        FormBorderStyle = FormBorderStyle.Sizable;
+        MinimizeBox = false;
+        MaximizeBox = true;
+        ShowInTaskbar = true;
+        ClientSize = new Size(468, 568);
+        MinimumSize = new Size(380, 380);
+
+        var titleLabel = new Label
+        {
+            Text = "Friend Notifications",
+            Font = new Font("Segoe UI", 13.5f, FontStyle.Bold),
+            ForeColor = TextColor,
+            Location = new Point(18, 16),
+            AutoSize = true
+        };
+
+        var subtitleLabel = new Label
+        {
+            Text = "Get a sound and a popup whenever a checked friend's status changes, for example when they finish a game.",
+            ForeColor = MutedColor,
+            Location = new Point(20, 50),
+            Size = new Size(430, 34),
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+        };
+
+        _enabledCheckBox = new CheckBox
+        {
+            Text = "Enable notifications",
+            Font = new Font("Segoe UI", 9.75f, FontStyle.Bold),
+            Location = new Point(18, 90),
+            AutoSize = true,
+            Checked = enabled
+        };
+        _enabledCheckBox.CheckedChanged += (_, _) => ApplyEnabledState(_enabledCheckBox.Checked);
+
+        _searchBox = new TextBox
+        {
+            Location = new Point(20, 120),
+            Size = new Size(428, 26),
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+            Enabled = enabled
+        };
+        _searchBox.TextChanged += (_, _) => Populate();
+
+        _statusIcons = new ImageList { ImageSize = new Size(12, 12), ColorDepth = ColorDepth.Depth32Bit };
+        foreach (var (status, color) in StatusPalette)
+            _statusIcons.Images.Add(status, CreateDot(color));
+
+        _friendColumn = new ColumnHeader { Text = "Friend", Width = 300 };
+        _statusColumn = new ColumnHeader { Text = "Status", Width = 140 };
+
+        _listView = new ListView
+        {
+            Location = new Point(20, 156),
+            Size = new Size(428, 358),
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+            View = View.Details,
+            CheckBoxes = true,
+            FullRowSelect = true,
+            MultiSelect = false,
+            HideSelection = true,
+            HeaderStyle = ColumnHeaderStyle.Nonclickable,
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.White,
+            SmallImageList = _statusIcons,
+            Enabled = enabled
+        };
+        _listView.Columns.AddRange(new[] { _friendColumn, _statusColumn });
+        _listView.ItemChecked += OnItemChecked;
+        _listView.Resize += (_, _) => ResizeColumns();
+
+        var footerPanel = new Panel
+        {
+            Dock = DockStyle.Bottom,
+            Height = 54,
+            BackColor = PanelColor
+        };
+        footerPanel.Paint += (_, e) =>
+        {
+            using var pen = new Pen(BorderColor);
+            e.Graphics.DrawLine(pen, 0, 0, footerPanel.Width, 0);
+        };
+
+        _countLabel = new Label
+        {
+            ForeColor = MutedColor,
+            AutoSize = true
+        };
+
+        var closeButton = new Button
+        {
+            Text = "Close",
+            Size = new Size(84, 30),
+            DialogResult = DialogResult.OK
+        };
+
+        // Position the footer contents whenever the (docked) panel is resized so we don't depend
+        // on its width before it has been laid out.
+        footerPanel.Resize += (_, _) =>
+        {
+            closeButton.Location = new Point(footerPanel.ClientSize.Width - closeButton.Width - 20, (footerPanel.ClientSize.Height - closeButton.Height) / 2);
+            _countLabel.Location = new Point(20, (footerPanel.ClientSize.Height - _countLabel.Height) / 2);
+        };
+
+        footerPanel.Controls.Add(_countLabel);
+        footerPanel.Controls.Add(closeButton);
+
+        AcceptButton = closeButton;
+        CancelButton = closeButton;
+
+        Controls.Add(_listView);
+        Controls.Add(_searchBox);
+        Controls.Add(_enabledCheckBox);
+        Controls.Add(subtitleLabel);
+        Controls.Add(titleLabel);
+        Controls.Add(footerPanel);
+
+        TrySetCueBanner();
+        ResizeColumns();
+        Populate();
+    }
+
+    private void ApplyEnabledState(bool enabled)
+    {
+        _setEnabled(enabled);
+        _searchBox.Enabled = enabled;
+        _listView.Enabled = enabled;
+    }
+
+    private void Populate()
+    {
+        _populating = true;
+        _listView.BeginUpdate();
+        _listView.Items.Clear();
+
+        var filter = _searchBox.Text.Trim();
+        var visible = _allFriends
+            .Where(friend => filter.Length == 0 || friend.RiotId.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
+            .OrderBy(friend => _tracked.Contains(friend.RiotId) ? 0 : 1) // tracked friends first
+            .ThenBy(friend => friend.IsOffline ? 1 : 0)                  // offline friends last
+            .ThenBy(friend => friend.RiotId, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var friend in visible)
+        {
+            var item = new ListViewItem(friend.RiotId)
+            {
+                ImageKey = friend.Status,
+                Checked = _tracked.Contains(friend.RiotId),
+                UseItemStyleForSubItems = false,
+                Tag = friend
+            };
+            var statusSubItem = item.SubItems.Add(friend.Status);
+            statusSubItem.ForeColor = StatusColor(friend.Status);
+            if (friend.IsOffline)
+                item.ForeColor = MutedColor;
+            _listView.Items.Add(item);
+        }
+
+        _listView.EndUpdate();
+        _populating = false;
+        UpdateCountLabel();
+    }
+
+    private void OnItemChecked(object sender, ItemCheckedEventArgs e)
+    {
+        if (_populating)
+            return;
+
+        var friend = (FriendItem)e.Item.Tag;
+        if (e.Item.Checked)
+            _tracked.Add(friend.RiotId);
+        else
+            _tracked.Remove(friend.RiotId);
+
+        _setTracked(friend.RiotId, e.Item.Checked);
+        UpdateCountLabel();
+    }
+
+    private void ResizeColumns()
+    {
+        var available = _listView.ClientSize.Width;
+        _statusColumn.Width = 140;
+        _friendColumn.Width = Math.Max(120, available - _statusColumn.Width - 4);
+    }
+
+    private void TrySetCueBanner()
+    {
+        try
+        {
+            SendMessage(_searchBox.Handle, EM_SETCUEBANNER, (IntPtr)1, "Search friends...");
+        }
+        catch
+        {
+            // cue banner is a nicety; ignore if the platform refuses it
+        }
+    }
+
+    private void UpdateCountLabel() => _countLabel.Text = _allFriends.Count == 0
+        ? "No friends loaded yet, log in first."
+        : $"{_tracked.Count} tracked, {_allFriends.Count} friends";
+
+    private static Color StatusColor(string status)
+    {
+        foreach (var (knownStatus, color) in StatusPalette)
+            if (string.Equals(knownStatus, status, StringComparison.OrdinalIgnoreCase))
+                return color;
+        return MutedColor;
+    }
+
+    private static Bitmap CreateDot(Color color)
+    {
+        var bitmap = new Bitmap(12, 12);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+        graphics.Clear(Color.Transparent);
+        using var brush = new SolidBrush(color);
+        graphics.FillEllipse(brush, 1, 2, 9, 9);
+        return bitmap;
+    }
+}

--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -2,9 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Media;
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -18,6 +23,11 @@ internal class MainController : ApplicationContext
 {
     internal MainController()
     {
+        // Hidden control used to marshal work back onto the UI thread from the
+        // background proxy loops (tray rebuilds, balloon tips, ...).
+        UiInvoker = new Control();
+        _ = UiInvoker.Handle; // force handle creation on the UI thread
+
         TrayIcon = new NotifyIcon
         {
             Icon = Resources.DeceiveIcon,
@@ -27,11 +37,16 @@ internal class MainController : ApplicationContext
         };
         TrayIcon.ShowBalloonTip(5000);
 
+        FriendNotificationsEnabled = Persistence.GetFriendNotificationsEnabled();
+        foreach (var friend in Persistence.GetTrackedFriends())
+            TrackedFriends.Add(friend);
+
         LoadStatus();
         UpdateTray();
     }
 
     private NotifyIcon TrayIcon { get; }
+    private Control UiInvoker { get; }
     public bool Enabled { get; set; } = true;
     public string Status { get; set; } = null!;
     private string StatusFile { get; } = Path.Combine(Persistence.DataDir, "status");
@@ -43,6 +58,16 @@ internal class MainController : ApplicationContext
     private ToolStripMenuItem ChatStatus { get; set; } = null!;
     private ToolStripMenuItem OfflineStatus { get; set; } = null!;
     private ToolStripMenuItem MobileStatus { get; set; } = null!;
+
+    // Friend status tracking. All access is guarded by FriendLock.
+    private readonly object FriendLock = new();
+    private bool FriendNotificationsEnabled;
+    private readonly HashSet<string> TrackedFriends = new(StringComparer.OrdinalIgnoreCase); // normalized "name#tag" Riot IDs
+    private readonly Dictionary<string, string> FriendNamesByPuuid = new(); // puuid -> "name#tag"
+    private readonly Dictionary<string, string> FriendLastStatus = new(); // puuid -> last seen presence status
+    private readonly Dictionary<string, string> FriendRosterState = new(); // puuid -> online/offline from roster (display fallback)
+
+    private const string FakePlayerPuuid = "41c322a1-b328-495b-a004-5ccd3e45eae8";
 
     private List<ProxiedConnection> Connections { get; } = new();
 
@@ -201,6 +226,8 @@ internal class MainController : ApplicationContext
 
         var startupStatusMenuItem = new ToolStripMenuItem("Default Status on Startup", null, startupOnline, startupOffline, startupMobile, startupLast);
 
+        var friendNotificationsMenuItem = new ToolStripMenuItem("Friend Notifications...", null, (_, _) => OpenFriendNotificationsForm());
+
         var restartWithDifferentGameItem = new ToolStripMenuItem("Restart and launch a different game", null, (_, _) =>
         {
             var result = MessageBox.Show(
@@ -247,57 +274,129 @@ internal class MainController : ApplicationContext
 
         TrayIcon.ContextMenuStrip.Items.AddRange(new ToolStripItem[]
         {
-            aboutMenuItem, EnabledMenuItem, typeMenuItem, startupStatusMenuItem, mucMenuItem, sendTestMsg, restartWithDifferentGameItem, quitMenuItem
+            aboutMenuItem, EnabledMenuItem, typeMenuItem, startupStatusMenuItem, friendNotificationsMenuItem, mucMenuItem, sendTestMsg, restartWithDifferentGameItem, quitMenuItem
         });
 #else
-        TrayIcon.ContextMenuStrip.Items.AddRange(new ToolStripItem[] { aboutMenuItem, EnabledMenuItem, typeMenuItem, startupStatusMenuItem, mucMenuItem, restartWithDifferentGameItem, quitMenuItem });
+        TrayIcon.ContextMenuStrip.Items.AddRange(new ToolStripItem[] { aboutMenuItem, EnabledMenuItem, typeMenuItem, startupStatusMenuItem, friendNotificationsMenuItem, mucMenuItem, restartWithDifferentGameItem, quitMenuItem });
 #endif
+    }
+
+    // Opens the modal window that lets the user toggle notifications and pick which friends to
+    // track. A dedicated window (rather than a tray submenu) is used because a roster can contain
+    // hundreds of friends, which would never fit in a context menu.
+    private void OpenFriendNotificationsForm()
+    {
+        List<KeyValuePair<string, string>> friends; // "name#tag" -> current status
+        HashSet<string> tracked;
+        bool enabled;
+        lock (FriendLock)
+        {
+            friends = FriendNamesByPuuid
+                .Select(pair => new KeyValuePair<string, string>(pair.Value, ResolveDisplayStatus(pair.Key)))
+                .GroupBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToList();
+            tracked = new HashSet<string>(TrackedFriends, StringComparer.OrdinalIgnoreCase);
+            enabled = FriendNotificationsEnabled;
+        }
+
+        using var form = new FriendNotificationsForm(friends, tracked, enabled, SetFriendNotificationsEnabled, SetFriendTracked);
+        form.ShowDialog();
+    }
+
+    // Best-known current status for display: a live presence status if we've seen one this session,
+    // otherwise the online/offline state from the roster. Must be called while holding FriendLock.
+    private string ResolveDisplayStatus(string puuid)
+    {
+        if (FriendLastStatus.TryGetValue(puuid, out var status))
+            return status;
+        if (FriendRosterState.TryGetValue(puuid, out var rosterState))
+            return rosterState;
+        return "Offline";
+    }
+
+    internal void SetFriendNotificationsEnabled(bool value)
+    {
+        lock (FriendLock)
+        {
+            FriendNotificationsEnabled = value;
+            Persistence.SetFriendNotificationsEnabled(value);
+        }
+    }
+
+    internal void SetFriendTracked(string riotId, bool tracked)
+    {
+        lock (FriendLock)
+        {
+            var changed = tracked ? TrackedFriends.Add(riotId) : TrackedFriends.Remove(riotId);
+            if (changed)
+                Persistence.SetTrackedFriends(TrackedFriends);
+        }
     }
 
     public async Task HandleChatMessage(string content)
     {
-        if (content.ToLower().Contains("offline"))
+        var body = (ExtractMessageBody(content) ?? content).Trim();
+        var lower = body.ToLowerInvariant();
+
+        // Friend tracking commands. Checked before the generic keyword matches below so that,
+        // for example, "/tracking" isn't swallowed by the "/track" prefix check.
+        if (lower is "/tracking" or "tracking" or "/tracked" or "tracked" or "/list" or "list")
+        {
+            await SendTrackedFriendsListAsync();
+        }
+        else if (lower.StartsWith("/untrack") || lower.StartsWith("untrack "))
+        {
+            await HandleTrackCommandAsync(body, track: false);
+        }
+        else if (lower.StartsWith("/track") || lower.StartsWith("track "))
+        {
+            await HandleTrackCommandAsync(body, track: true);
+        }
+        else if (lower.Contains("offline"))
         {
             if (!Enabled)
                 await SendMessageFromFakePlayerAsync("Deceive is now enabled.");
             OfflineStatus.PerformClick();
         }
-        else if (content.ToLower().Contains("mobile"))
+        else if (lower.Contains("mobile"))
         {
             if (!Enabled)
                 await SendMessageFromFakePlayerAsync("Deceive is now enabled.");
             MobileStatus.PerformClick();
         }
-        else if (content.ToLower().Contains("online"))
+        else if (lower.Contains("online"))
         {
             if (!Enabled)
                 await SendMessageFromFakePlayerAsync("Deceive is now enabled.");
             ChatStatus.PerformClick();
         }
-        else if (content.ToLower().Contains("enable"))
+        else if (lower.Contains("enable"))
         {
             if (Enabled)
                 await SendMessageFromFakePlayerAsync("Deceive is already enabled.");
             else
                 EnabledMenuItem.PerformClick();
         }
-        else if (content.ToLower().Contains("disable"))
+        else if (lower.Contains("disable"))
         {
             if (!Enabled)
                 await SendMessageFromFakePlayerAsync("Deceive is already disabled.");
             else
                 EnabledMenuItem.PerformClick();
         }
-        else if (content.ToLower().Contains("status"))
+        else if (lower.Contains("status"))
         {
             if (Status == "chat")
                 await SendMessageFromFakePlayerAsync("You are appearing online.");
             else
                 await SendMessageFromFakePlayerAsync("You are appearing " + Status + ".");
         }
-        else if (content.ToLower().Contains("help"))
+        else if (lower.Contains("help"))
         {
             await SendMessageFromFakePlayerAsync("You can send the following messages to quickly change Deceive settings: online/offline/mobile/enable/disable/status");
+            await SendMessageFromFakePlayerAsync(
+                "Friend notifications: /track <name#tag> to be notified whenever that friend's status changes, /untrack <name#tag> to stop, /tracking to list tracked friends.");
         }
     }
 
@@ -320,6 +419,301 @@ internal class MainController : ApplicationContext
         foreach (var connection in Connections)
             await connection.SendMessageFromFakePlayerAsync(message);
     }
+
+    #region Friend status notifications
+
+    private async Task HandleTrackCommandAsync(string body, bool track)
+    {
+        var riotId = ParseCommandArgument(body);
+        if (riotId is null)
+        {
+            await SendMessageFromFakePlayerAsync(track
+                ? "Usage: /track <name#tag> to get notified whenever that friend's status changes (e.g. when they finish a game)."
+                : "Usage: /untrack <name#tag>.");
+            return;
+        }
+
+        bool changed;
+        bool known;
+        lock (FriendLock)
+        {
+            known = FriendNamesByPuuid.Values.Any(value => string.Equals(value, riotId, StringComparison.OrdinalIgnoreCase));
+            changed = track ? TrackedFriends.Add(riotId) : TrackedFriends.Remove(riotId);
+            if (changed)
+                Persistence.SetTrackedFriends(TrackedFriends);
+        }
+
+        if (track)
+        {
+            if (!changed)
+                await SendMessageFromFakePlayerAsync($"Already tracking {riotId}.");
+            else if (known)
+                await SendMessageFromFakePlayerAsync($"Now tracking {riotId}. You'll be notified whenever their status changes.");
+            else
+                await SendMessageFromFakePlayerAsync($"Now tracking {riotId}. Note: no friend with that Riot ID is loaded yet, double-check the spelling (name#tag).");
+        }
+        else
+        {
+            await SendMessageFromFakePlayerAsync(changed ? $"No longer tracking {riotId}." : $"{riotId} wasn't being tracked.");
+        }
+    }
+
+    private async Task SendTrackedFriendsListAsync()
+    {
+        List<string> tracked;
+        lock (FriendLock)
+            tracked = TrackedFriends.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList();
+
+        await SendMessageFromFakePlayerAsync(tracked.Count == 0
+            ? "You aren't tracking any friends. Use /track <name#tag> to start."
+            : "Currently tracking: " + string.Join(", ", tracked));
+    }
+
+    // Parses the argument of a "/command argument" message, stripping surrounding quotes.
+    private static string? ParseCommandArgument(string body)
+    {
+        var spaceIndex = body.IndexOf(' ');
+        if (spaceIndex < 0)
+            return null;
+
+        var argument = body.Substring(spaceIndex + 1).Trim();
+        if (argument.Length >= 2 && argument[0] == '"' && argument[argument.Length - 1] == '"')
+            argument = argument.Substring(1, argument.Length - 2).Trim();
+
+        return argument.Length == 0 ? null : argument;
+    }
+
+    private static string? ExtractMessageBody(string content)
+    {
+        const string open = "<body>";
+        const string close = "</body>";
+        var start = content.IndexOf(open, StringComparison.Ordinal);
+        if (start < 0)
+            return null;
+        start += open.Length;
+        var end = content.IndexOf(close, start, StringComparison.Ordinal);
+        return end < 0 ? null : WebUtility.HtmlDecode(content.Substring(start, end - start));
+    }
+
+    // Parses the roster stanza sent by the server to learn the puuid -> "name#tag" mapping so that
+    // we can resolve incoming friend presences (which only carry the puuid) to a readable Riot ID.
+    internal void HandleRosterContent(string content)
+    {
+        // Extract just the <query>...</query> element. The buffered content also contains the
+        // enclosing (and unclosed, when split) <iq> wrapper plus any trailing stanzas, which would
+        // otherwise make the document fail to parse.
+        const string openMarker = "<query xmlns='jabber:iq:riotgames:roster'>";
+        const string closeMarker = "</query>";
+        var start = content.IndexOf(openMarker, StringComparison.Ordinal);
+        if (start < 0)
+            return;
+        var end = content.IndexOf(closeMarker, start, StringComparison.Ordinal);
+        if (end < 0)
+            return;
+        var queryXml = content.Substring(start, end - start + closeMarker.Length);
+
+        try
+        {
+            var xml = XDocument.Load(new StringReader("<xml>" + queryXml + "</xml>"));
+            var count = 0;
+            foreach (var item in xml.Descendants().Where(element => element.Name.LocalName == "item"))
+            {
+                var jid = item.Attribute("jid")?.Value;
+                if (string.IsNullOrEmpty(jid))
+                    continue;
+
+                var puuid = jid!.Split('@')[0];
+                if (puuid == FakePlayerPuuid)
+                    continue;
+
+                var riotId = ExtractRiotId(item);
+                if (riotId is null)
+                    continue;
+
+                var state = item.Elements().FirstOrDefault(element => element.Name.LocalName == "state")?.Value;
+                lock (FriendLock)
+                {
+                    FriendNamesByPuuid[puuid] = riotId;
+                    if (!string.IsNullOrEmpty(state))
+                        FriendRosterState[puuid] = MapRosterState(state!);
+                }
+
+                count++;
+            }
+
+            Trace.WriteLine($"Parsed {count} friends from roster for friend tracking.");
+        }
+        catch (Exception e)
+        {
+            Trace.WriteLine("Failed to parse roster for friend tracking.");
+            Trace.WriteLine(e);
+        }
+    }
+
+    private static string MapRosterState(string state) => state.ToLowerInvariant() switch
+    {
+        "offline" => "Offline",
+        "mobile" => "Mobile",
+        _ => "Online"
+    };
+
+    private static string? ExtractRiotId(XElement item)
+    {
+        var id = item.Elements().FirstOrDefault(element => element.Name.LocalName == "id");
+        var name = id?.Attribute("name")?.Value;
+        var tagline = id?.Attribute("tagline")?.Value;
+        if (!string.IsNullOrWhiteSpace(name))
+            return string.IsNullOrWhiteSpace(tagline) ? name!.Trim() : name!.Trim() + "#" + tagline!.Trim();
+
+        var lolName = item.Elements().FirstOrDefault(element => element.Name.LocalName == "lol")?.Attribute("name")?.Value;
+        if (!string.IsNullOrWhiteSpace(lolName))
+            return lolName!.Trim();
+
+        var attributeName = item.Attribute("name")?.Value;
+        return string.IsNullOrWhiteSpace(attributeName) ? null : attributeName!.Trim();
+    }
+
+    // Observes incoming friend presences and notifies the user when a tracked friend's status
+    // changes. The very first presence seen for a friend in a session is recorded silently so that
+    // we don't fire a burst of notifications right after logging in.
+    internal void HandleFriendPresenceContent(string content)
+    {
+        XDocument xml;
+        try
+        {
+            xml = XDocument.Load(new StringReader("<xml>" + content + "</xml>"));
+        }
+        catch
+        {
+            return; // partial or non-XML chunk; ignore
+        }
+
+        if (xml.Root is null)
+            return;
+
+        foreach (var presence in xml.Root.Elements().Where(element => element.Name.LocalName == "presence"))
+        {
+            var from = presence.Attribute("from")?.Value;
+            if (string.IsNullOrEmpty(from))
+                continue;
+
+            var puuid = from!.Split('@')[0];
+            if (puuid == FakePlayerPuuid)
+                continue;
+
+            var status = ComputeFriendStatus(presence);
+
+            string? riotId;
+            string? previous;
+            bool tracked;
+            bool enabled;
+            lock (FriendLock)
+            {
+                FriendNamesByPuuid.TryGetValue(puuid, out riotId);
+                FriendLastStatus.TryGetValue(puuid, out previous);
+                FriendLastStatus[puuid] = status;
+                enabled = FriendNotificationsEnabled;
+                tracked = riotId is not null && TrackedFriends.Contains(riotId);
+            }
+
+            if (!enabled || !tracked)
+                continue;
+            if (previous is null || previous == status)
+                continue; // first sighting this session, or just a heartbeat with no real change
+
+            NotifyFriendStatusChanged(riotId!, status);
+        }
+    }
+
+    // Reduces a presence stanza to the human-readable status shown in the friends list.
+    private static string ComputeFriendStatus(XElement presence)
+    {
+        if (presence.Attribute("type")?.Value == "unavailable")
+            return "Offline";
+
+        var games = presence.Elements().FirstOrDefault(element => element.Name.LocalName == "games");
+        var lol = games?.Elements().FirstOrDefault(element => element.Name.LocalName == "league_of_legends");
+        var payload = lol?.Elements().FirstOrDefault(element => element.Name.LocalName == "p")?.Value;
+        if (!string.IsNullOrWhiteSpace(payload))
+        {
+            try
+            {
+                var gameStatus = JsonSerializer.Deserialize<JsonNode>(payload!)?["gameStatus"]?.GetValue<string>();
+                switch (gameStatus)
+                {
+                    case "inGame":
+                        return "In Game";
+                    case "championSelect":
+                        return "In Champion Select";
+                    case "inQueue":
+                        return "In Queue";
+                    case "spectating":
+                        return "Spectating";
+                    case null or "" or "outOfGame":
+                        break; // fall through to the availability-based status
+                    default:
+                        if (gameStatus!.StartsWith("hosting_", StringComparison.Ordinal))
+                            return "In Lobby";
+                        break;
+                }
+            }
+            catch
+            {
+                // malformed payload; fall through to the availability-based status
+            }
+        }
+
+        var show = presence.Elements().FirstOrDefault(element => element.Name.LocalName == "show")?.Value;
+        return show switch
+        {
+            "away" => "Away",
+            "dnd" => "Busy",
+            "mobile" => "Mobile",
+            _ => "Online"
+        };
+    }
+
+    private void NotifyFriendStatusChanged(string riotId, string status)
+    {
+        var message = $"{riotId} is now {status}.";
+        Trace.WriteLine("Friend status notification: " + message);
+
+        PostToUi(() =>
+        {
+            try
+            {
+                TrayIcon.BalloonTipTitle = "Deceive: Friend status changed";
+                TrayIcon.BalloonTipText = message;
+                TrayIcon.ShowBalloonTip(5000);
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e);
+            }
+        });
+
+        try
+        {
+            SystemSounds.Exclamation.Play();
+        }
+        catch
+        {
+            // no audio device / sound disabled; ignore
+        }
+
+        _ = SendMessageFromFakePlayerAsync(message);
+    }
+
+    // Marshals an action onto the UI thread that owns the tray icon.
+    private void PostToUi(Action action)
+    {
+        if (UiInvoker.IsHandleCreated && UiInvoker.InvokeRequired)
+            UiInvoker.BeginInvoke(action);
+        else
+            action();
+    }
+
+    #endregion
 
     private async Task UpdateStatusAsync(string newStatus)
     {

--- a/Deceive/Persistence.cs
+++ b/Deceive/Persistence.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Deceive;
@@ -12,6 +14,8 @@ internal static class Persistence
     private static readonly string DefaultLaunchGamePath = Path.Combine(DataDir, "launchGame");
     private static readonly string CachedCertPath = Path.Combine(DataDir, "localhostCert.pfx");
     private static readonly string StartupStatusPath = Path.Combine(DataDir, "startupStatus");
+    private static readonly string TrackedFriendsPath = Path.Combine(DataDir, "trackedFriends");
+    private static readonly string FriendNotificationsPath = Path.Combine(DataDir, "friendNotifications");
 
     static Persistence()
     {
@@ -62,4 +66,22 @@ internal static class Persistence
     // Startup status: "chat", "offline", "mobile", or "last" (remember last session).
     internal static string GetStartupStatus() => File.Exists(StartupStatusPath) ? File.ReadAllText(StartupStatusPath) : "last";
     internal static void SetStartupStatus(string status) => File.WriteAllText(StartupStatusPath, status);
+
+    // Friends whose status changes we notify about, stored as one normalized "name#tag" Riot ID per line.
+    internal static List<string> GetTrackedFriends()
+    {
+        if (!File.Exists(TrackedFriendsPath))
+            return new List<string>();
+
+        return File.ReadAllLines(TrackedFriendsPath)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+    }
+
+    internal static void SetTrackedFriends(IEnumerable<string> friends) => File.WriteAllLines(TrackedFriendsPath, friends);
+
+    // Whether friend status change notifications are enabled (defaults to true).
+    internal static bool GetFriendNotificationsEnabled() => !File.Exists(FriendNotificationsPath) || File.ReadAllText(FriendNotificationsPath).Trim() != "false";
+    internal static void SetFriendNotificationsEnabled(bool enabled) => File.WriteAllText(FriendNotificationsPath, enabled ? "true" : "false");
 }

--- a/Deceive/ProxiedConnection.cs
+++ b/Deceive/ProxiedConnection.cs
@@ -22,6 +22,8 @@ internal class ProxiedConnection
     private bool InsertedFakePlayer { get; set; } = false;
     private bool SentFakePlayerPresence { get; set; } = false;
     private string? ValorantVersion { get; set; } = null;
+    private MemoryStream? RosterBuffer { get; set; } = null;
+    private string PresenceBuffer { get; set; } = "";
 
     internal event EventHandler? ConnectionErrored;
 
@@ -101,6 +103,27 @@ internal class ProxiedConnection
 
                 // Insert fake player into roster
                 const string roster = "<query xmlns='jabber:iq:riotgames:roster'>";
+
+                // Capture the roster for friend tracking. It can span multiple reads, so we buffer
+                // the raw bytes (decoding per-chunk would corrupt multi-byte characters split across
+                // a read boundary) until the closing </query> arrives, then decode it all at once.
+                if (RosterBuffer is null && content.Contains(roster))
+                    RosterBuffer = new MemoryStream();
+                if (RosterBuffer is not null)
+                {
+                    RosterBuffer.Write(bytes, 0, byteCount);
+                    var buffered = Encoding.UTF8.GetString(RosterBuffer.ToArray());
+                    var openIndex = buffered.IndexOf(roster, StringComparison.Ordinal);
+                    var closed = openIndex >= 0 && buffered.IndexOf("</query>", openIndex, StringComparison.Ordinal) >= 0;
+                    if (closed || RosterBuffer.Length > 8 * 1024 * 1024)
+                    {
+                        if (closed)
+                            MainController.HandleRosterContent(buffered);
+                        RosterBuffer.Dispose();
+                        RosterBuffer = null;
+                    }
+                }
+
                 if (!InsertedFakePlayer && content.Contains(roster))
                 {
                     InsertedFakePlayer = true;
@@ -122,6 +145,12 @@ internal class ProxiedConnection
                     await Incoming.WriteAsync(bytes, 0, byteCount);
                     Trace.WriteLine("<!--SERVER TO RC-->" + content);
                 }
+
+                // Observe friend presences (for status change notifications) without altering the
+                // forwarded data. Presences can span multiple reads (especially the burst at login),
+                // so they are reassembled into complete stanzas before being parsed.
+                if (content.Contains("<presence") || PresenceBuffer.Length > 0)
+                    ObserveFriendPresence(content);
             } while (byteCount != 0 && Connected);
         }
         catch (Exception e)
@@ -133,6 +162,63 @@ internal class ProxiedConnection
         {
             Trace.WriteLine("Outgoing closed.");
             OnConnectionErrored();
+        }
+    }
+
+    // Reassembles the (possibly fragmented) server-to-client stream into complete <presence>
+    // stanzas and hands each one to the controller. Any trailing partial stanza is kept in the
+    // buffer for the next read.
+    private void ObserveFriendPresence(string content)
+    {
+        PresenceBuffer += content;
+        if (PresenceBuffer.Length > 4 * 1024 * 1024)
+        {
+            // Runaway guard: a presence stanza should never be this large.
+            PresenceBuffer = "";
+            return;
+        }
+
+        var searchStart = 0;
+        while (true)
+        {
+            var open = PresenceBuffer.IndexOf("<presence", searchStart, StringComparison.Ordinal);
+            if (open < 0)
+            {
+                // Keep a trailing fragment only if it could be the start of "<presence".
+                var lt = PresenceBuffer.LastIndexOf('<');
+                var tail = lt >= 0 ? PresenceBuffer.Substring(lt) : "";
+                PresenceBuffer = "<presence".StartsWith(tail, StringComparison.Ordinal) ? tail : "";
+                return;
+            }
+
+            var tagEnd = PresenceBuffer.IndexOf('>', open);
+            if (tagEnd < 0)
+            {
+                PresenceBuffer = PresenceBuffer.Substring(open); // incomplete start tag
+                return;
+            }
+
+            int stanzaEnd;
+            if (PresenceBuffer[tagEnd - 1] == '/')
+            {
+                stanzaEnd = tagEnd + 1; // self-closing <presence .../>
+            }
+            else
+            {
+                const string closeTag = "</presence>";
+                var close = PresenceBuffer.IndexOf(closeTag, tagEnd, StringComparison.Ordinal);
+                if (close < 0)
+                {
+                    PresenceBuffer = PresenceBuffer.Substring(open); // stanza not complete yet
+                    return;
+                }
+
+                stanzaEnd = close + closeTag.Length;
+            }
+
+            var stanza = PresenceBuffer.Substring(open, stanzaEnd - open);
+            MainController.HandleFriendPresenceContent(stanza);
+            searchStart = stanzaEnd;
         }
     }
 


### PR DESCRIPTION
Hey! I built a feature I wanted for myself and figured it might be useful for others too, so I'm sharing it back.

## What it does
You can pick friends and get a sound plus a tray balloon (and a message in the Deceive chat) whenever one of them changes status, for example when a friend finishes a game and goes back to the lobby or comes online.

## How to use it
Two ways to choose who to track:
- In the Deceive chat: `/track <name#tag>`, `/untrack <name#tag>`, and `/tracking` to list the ones you're tracking.
- A new "Friend Notifications" item in the tray menu opens a window with a searchable, scrollable list of your friends and their current status. Tracked friends are shown first and offline ones last, and there's a master on/off toggle. Your selection is saved across sessions.

## How it works
- The roster is buffered across reads and parsed to map each friend's puuid to their Riot ID (name#tag), since presences only carry the puuid.
- Incoming friend presences are reassembled into complete stanzas before parsing, because the presence burst at login is large and gets fragmented across TCP reads. The forwarded data itself is not touched, it is observed only.
- The LoL gameStatus (or otherwise the availability) is reduced to a readable status, and a notification fires when a tracked friend's status changes. The first status seen per friend each session is recorded silently so you don't get a burst of notifications right after logging in.

No existing behaviour is changed, everything is additive. I have been running it on my own account for a while and it works well for me. Happy to change anything if you'd prefer a different approach. Thanks for Deceive!
