### PR TITLE
Show introduction text only on first run

### DIFF
--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -107,7 +107,7 @@ internal class MainController : ApplicationContext
                 };
                 Connections.Add(proxiedConnection);
 
-                if (!SentIntroductionText)
+                if (!SentIntroductionText && !Persistence.GetHasShownIntroduction())
                 {
                     SentIntroductionText = true;
                     _ = Task.Run(async () =>
@@ -303,7 +303,7 @@ internal class MainController : ApplicationContext
 
     private async Task SendIntroductionTextAsync()
     {
-        SentIntroductionText = true;
+        Persistence.SetHasShownIntroduction();
         await SendMessageFromFakePlayerAsync("Welcome! Deceive is running and you are currently appearing " + Status +
                                              ". Despite what the game client may indicate, you are appearing offline to your friends unless you manually disable Deceive.");
         await Task.Delay(200);

--- a/Deceive/Persistence.cs
+++ b/Deceive/Persistence.cs
@@ -12,6 +12,7 @@ internal static class Persistence
     private static readonly string DefaultLaunchGamePath = Path.Combine(DataDir, "launchGame");
     private static readonly string CachedCertPath = Path.Combine(DataDir, "localhostCert.pfx");
     private static readonly string StartupStatusPath = Path.Combine(DataDir, "startupStatus");
+    private static readonly string IntroductionShownPath = Path.Combine(DataDir, "introductionShown");
 
     static Persistence()
     {
@@ -62,4 +63,8 @@ internal static class Persistence
     // Startup status: "chat", "offline", "mobile", or "last" (remember last session).
     internal static string GetStartupStatus() => File.Exists(StartupStatusPath) ? File.ReadAllText(StartupStatusPath) : "last";
     internal static void SetStartupStatus(string status) => File.WriteAllText(StartupStatusPath, status);
+
+    // Whether the introduction/welcome text has already been shown to the user.
+    internal static bool GetHasShownIntroduction() => File.Exists(IntroductionShownPath);
+    internal static void SetHasShownIntroduction() => File.WriteAllText(IntroductionShownPath, string.Empty);
 }


### PR DESCRIPTION
**TLDR:** The welcome message popped up every time Deceive started. This PR makes it show only on the first run.

Deceive sends its introduction text on every launch. `SentIntroductionText` is only an in-memory flag, so it resets each time the app restarts and the message shows up again. This PR persists the "shown" state so the message is only displayed once.

### Changes

- In `Persistence.cs`, I added `GetHasShownIntroduction()` and `SetHasShownIntroduction()`. They're backed by a sentinel `introductionShown` file in Deceive's AppData directory, the same file-based pattern the other persisted settings already use (`startupStatus` and `launchGame`).
- In `MainController.cs`, the startup guard also checks `Persistence.GetHasShownIntroduction()`, so the intro is skipped on later launches.
- `SendIntroductionTextAsync` writes the persistent flag instead of redundantly setting the in-memory one.

This resolves #74.