### PR TITLE
fix: show introduction text only on first run

### DIFF
--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -36,7 +36,7 @@ internal class MainController : ApplicationContext
     public string Status { get; set; } = null!;
     private string StatusFile { get; } = Path.Combine(Persistence.DataDir, "status");
     public bool ConnectToMuc { get; set; } = true;
-    private bool SentIntroductionText { get; set; } = false;
+    private bool SentIntroductionText { get; set; } = Persistence.GetHasShownIntroduction();
     private CancellationTokenSource? ShutdownToken { get; set; } = null;
 
     private ToolStripMenuItem EnabledMenuItem { get; set; } = null!;
@@ -303,6 +303,7 @@ internal class MainController : ApplicationContext
 
     private async Task SendIntroductionTextAsync()
     {
+        Persistence.SetHasShownIntroduction();
         SentIntroductionText = true;
         await SendMessageFromFakePlayerAsync("Welcome! Deceive is running and you are currently appearing " + Status +
                                              ". Despite what the game client may indicate, you are appearing offline to your friends unless you manually disable Deceive.");

--- a/Deceive/Persistence.cs
+++ b/Deceive/Persistence.cs
@@ -12,6 +12,7 @@ internal static class Persistence
     private static readonly string DefaultLaunchGamePath = Path.Combine(DataDir, "launchGame");
     private static readonly string CachedCertPath = Path.Combine(DataDir, "localhostCert.pfx");
     private static readonly string StartupStatusPath = Path.Combine(DataDir, "startupStatus");
+    private static readonly string IntroductionShownPath = Path.Combine(DataDir, "introductionShown");
 
     static Persistence()
     {
@@ -62,4 +63,8 @@ internal static class Persistence
     // Startup status: "chat", "offline", "mobile", or "last" (remember last session).
     internal static string GetStartupStatus() => File.Exists(StartupStatusPath) ? File.ReadAllText(StartupStatusPath) : "last";
     internal static void SetStartupStatus(string status) => File.WriteAllText(StartupStatusPath, status);
+
+    // Has shown introduction text.
+    internal static bool GetHasShownIntroduction() => File.Exists(IntroductionShownPath);
+    internal static void SetHasShownIntroduction() => File.WriteAllText(IntroductionShownPath, "1");
 }


### PR DESCRIPTION
Persist introduction shown state via sentinel file so welcome message is only displayed once. Closes #306