### PR TITLE
Feature/keep valorant user title and banner in lobby

### DIFF
--- a/Deceive/MainController.cs
+++ b/Deceive/MainController.cs
@@ -16,6 +16,8 @@ namespace Deceive;
 
 internal class MainController : ApplicationContext
 {
+    private const string ValorantLobbyStatusLabel = "Offline with VALORANT Lobby Info (LoR Away)";
+
     internal MainController()
     {
         TrayIcon = new NotifyIcon
@@ -43,6 +45,7 @@ internal class MainController : ApplicationContext
     private ToolStripMenuItem ChatStatus { get; set; } = null!;
     private ToolStripMenuItem OfflineStatus { get; set; } = null!;
     private ToolStripMenuItem MobileStatus { get; set; } = null!;
+    private ToolStripMenuItem ValorantLobbyStatus { get; set; } = null!;
 
     private List<ProxiedConnection> Connections { get; } = new();
 
@@ -168,7 +171,15 @@ internal class MainController : ApplicationContext
         })
         { Checked = Status.Equals("mobile") };
 
-        var typeMenuItem = new ToolStripMenuItem("Status Type", null, ChatStatus, OfflineStatus, MobileStatus);
+        ValorantLobbyStatus = new ToolStripMenuItem(ValorantLobbyStatusLabel, null, async (_, _) =>
+        {
+            await UpdateStatusAsync(Status = ProxiedConnection.ValorantLobbyStatus);
+            Enabled = true;
+            UpdateTray();
+        })
+        { Checked = Status.Equals(ProxiedConnection.ValorantLobbyStatus) };
+
+        var typeMenuItem = new ToolStripMenuItem("Status Type", null, ChatStatus, OfflineStatus, MobileStatus, ValorantLobbyStatus);
         
         var currentStartup = Persistence.GetStartupStatus();
         var startupOnline = new ToolStripMenuItem("Online", null, (_, _) =>
@@ -192,6 +203,13 @@ internal class MainController : ApplicationContext
         })
         { Checked = currentStartup == "mobile" };
 
+        var startupValorantLobby = new ToolStripMenuItem(ValorantLobbyStatusLabel, null, (_, _) =>
+        {
+            Persistence.SetStartupStatus(ProxiedConnection.ValorantLobbyStatus);
+            UpdateTray();
+        })
+        { Checked = currentStartup == ProxiedConnection.ValorantLobbyStatus };
+
         var startupLast = new ToolStripMenuItem("Remember Last", null, (_, _) =>
         {
             Persistence.SetStartupStatus("last");
@@ -199,7 +217,7 @@ internal class MainController : ApplicationContext
         })
         { Checked = currentStartup == "last" };
 
-        var startupStatusMenuItem = new ToolStripMenuItem("Default Status on Startup", null, startupOnline, startupOffline, startupMobile, startupLast);
+        var startupStatusMenuItem = new ToolStripMenuItem("Default Status on Startup", null, startupOnline, startupOffline, startupMobile, startupValorantLobby, startupLast);
 
         var restartWithDifferentGameItem = new ToolStripMenuItem("Restart and launch a different game", null, (_, _) =>
         {
@@ -290,10 +308,7 @@ internal class MainController : ApplicationContext
         }
         else if (content.ToLower().Contains("status"))
         {
-            if (Status == "chat")
-                await SendMessageFromFakePlayerAsync("You are appearing online.");
-            else
-                await SendMessageFromFakePlayerAsync("You are appearing " + Status + ".");
+            await SendMessageFromFakePlayerAsync("You are appearing " + DescribeStatus(Status) + ".");
         }
         else if (content.ToLower().Contains("help"))
         {
@@ -304,8 +319,11 @@ internal class MainController : ApplicationContext
     private async Task SendIntroductionTextAsync()
     {
         Persistence.SetHasShownIntroduction();
-        await SendMessageFromFakePlayerAsync("Welcome! Deceive is running and you are currently appearing " + Status +
-                                             ". Despite what the game client may indicate, you are appearing offline to your friends unless you manually disable Deceive.");
+        var statusExplanation = Status == ProxiedConnection.ValorantLobbyStatus
+            ? "VALORANT lobby information remains visible, while Riot Client shows mock Legends of Runeterra away presence."
+            : "Despite what the game client may indicate, you are appearing offline to your friends unless you manually disable Deceive.";
+        await SendMessageFromFakePlayerAsync("Welcome! Deceive is running and you are currently appearing " +
+                                             DescribeStatus(Status) + ". " + statusExplanation);
         await Task.Delay(200);
         await SendMessageFromFakePlayerAsync(
             "If you want to invite others while being offline, you may need to disable Deceive for them to accept. You can enable Deceive again as soon as they are in your lobby.");
@@ -326,17 +344,15 @@ internal class MainController : ApplicationContext
         foreach (var connection in Connections)
             await connection.UpdateStatusAsync(newStatus);
 
-        if (newStatus == "chat")
-            await SendMessageFromFakePlayerAsync("You are now appearing online.");
-        else
-            await SendMessageFromFakePlayerAsync("You are now appearing " + newStatus + ".");
+        await SendMessageFromFakePlayerAsync("You are now appearing " + DescribeStatus(newStatus) + ".");
     }
 
     private void LoadStatus()
     {
         var startupStatus = Persistence.GetStartupStatus();
 
-        if (startupStatus is "chat" or "offline" or "mobile")
+        if (startupStatus is "chat" or "offline" or "mobile" ||
+            startupStatus == ProxiedConnection.ValorantLobbyStatus)
         {
             Status = startupStatus;
             return;
@@ -354,9 +370,17 @@ internal class MainController : ApplicationContext
         {
             "chat" => "chat",
             "mobile" => "mobile",
+            ProxiedConnection.ValorantLobbyStatus => ProxiedConnection.ValorantLobbyStatus,
             _ => "offline"
         };
     }
+
+    private static string DescribeStatus(string status) => status switch
+    {
+        "chat" => "online",
+        ProxiedConnection.ValorantLobbyStatus => "offline with VALORANT lobby info (mock LoR away)",
+        _ => status
+    };
 
     private async Task ShutdownIfNoReconnect()
     {

--- a/Deceive/Persistence.cs
+++ b/Deceive/Persistence.cs
@@ -60,7 +60,7 @@ internal static class Persistence
     
     internal static void SetCachedCertificate(byte[] certBytes) => File.WriteAllBytes(CachedCertPath, certBytes);
     
-    // Startup status: "chat", "offline", "mobile", or "last" (remember last session).
+    // Startup status: "chat", "offline", "mobile", "valorant_lobby", or "last" (remember last session).
     internal static string GetStartupStatus() => File.Exists(StartupStatusPath) ? File.ReadAllText(StartupStatusPath) : "last";
     internal static void SetStartupStatus(string status) => File.WriteAllText(StartupStatusPath, status);
 

--- a/Deceive/PresenceScrub.cs
+++ b/Deceive/PresenceScrub.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Xml.Linq;
+
+namespace Deceive;
+
+static class PresenceScrub
+{
+    public static void ScrubValorantPresence(XElement presence)
+    {
+        var valorantNode = presence.Element("games")?.Element("valorant");
+        if (valorantNode == null) return;
+
+        ScrubBase64Element(valorantNode, "p", RebuildP);
+        // Do NOT remove valorantNode anymore.
+    }
+
+    private static void ScrubBase64Element(XElement valorantNode, string elementName, Func<JsonObject, JsonObject> rebuild)
+    {
+        var el = valorantNode.Element(elementName);
+        if (el == null || string.IsNullOrEmpty(el.Value)) return;
+
+        byte[] raw;
+        try { raw = Convert.FromBase64String(el.Value); }
+        catch { return; }
+
+        JsonObject? obj;
+        try { obj = JsonNode.Parse(Encoding.UTF8.GetString(raw))?.AsObject(); }
+        catch { return; }
+        if (obj == null) return;
+
+        var rebuilt = rebuild(obj);
+        var json = rebuilt.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+        el.Value = Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    // Keep ONLY playerPresenceData (card/title/level/etc). Everything else
+    // becomes a minimal, schema-valid, non-revealing default — never deleted,
+    // just blanked, so the client's deserializer doesn't choke on a missing key.
+    private static JsonObject RebuildP(JsonObject original)
+    {
+        var playerPresenceDataNode = original["playerPresenceData"];
+        var playerPresenceData = playerPresenceDataNode != null
+            ? JsonNode.Parse(playerPresenceDataNode.ToJsonString())!.AsObject()
+            : new JsonObject();
+
+        return new JsonObject
+        {
+            ["isValid"] = true,
+            ["playerPresenceData"] = playerPresenceData, 
+        };
+    }
+}

--- a/Deceive/PresenceScrub.cs
+++ b/Deceive/PresenceScrub.cs
@@ -10,10 +10,26 @@ static class PresenceScrub
 {
     public static void ScrubValorantPresence(XElement presence)
     {
-        var valorantNode = presence.Element("games")?.Element("valorant");
+        var gamesNode = presence.Element("games");
+        var valorantNode = gamesNode?.Element("valorant");
         if (valorantNode == null) return;
 
+        // VALORANT needs an active product status to render the player card in a
+        // party. The separate party/activity payload is not needed for that.
+        valorantNode.Element("pd")?.Remove();
+        // Away is the least-visible tested status that still renders the lobby card.
+        valorantNode.SetElementValue("st", "away");
         ScrubBase64Element(valorantNode, "p", RebuildP);
+
+        // Riot Client selects the newer product presence, masking VALORANT as
+        // Legends of Runeterra away while VALORANT still reads its lobby data.
+        var timestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        gamesNode!.Add(
+            new XElement("bacon",
+                new XElement("st", "away"),
+                new XElement("s.t", timestamp),
+                new XElement("s.p", "bacon"),
+                new XElement("pty")));
         // Do NOT remove valorantNode anymore.
     }
 

--- a/Deceive/ProxiedConnection.cs
+++ b/Deceive/ProxiedConnection.cs
@@ -13,6 +13,8 @@ namespace Deceive;
 
 internal class ProxiedConnection
 {
+    internal const string ValorantLobbyStatus = "valorant_lobby";
+
     private MainController MainController { get; set; }
 
     private SslStream Incoming { get; set; } = null!;
@@ -160,11 +162,15 @@ internal class ProxiedConnection
                     presence.Remove();
                 }
 
-                if (targetStatus != "chat" ||
+                // The lobby-compatible mode is globally offline, but retains a
+                // deliberately limited VALORANT presence below.
+                var xmppStatus = targetStatus == ValorantLobbyStatus ? "offline" : targetStatus;
+
+                if (xmppStatus != "chat" ||
                     presence.Element("games")?.Element("league_of_legends")?.Element("st")?.Value != "dnd")
                 {
-                    presence.Element("show")?.ReplaceNodes(targetStatus);
-                    presence.Element("games")?.Element("league_of_legends")?.Element("st")?.ReplaceNodes(targetStatus);
+                    presence.Element("show")?.ReplaceNodes(xmppStatus);
+                    presence.Element("games")?.Element("league_of_legends")?.Element("st")?.ReplaceNodes(xmppStatus);
                 }
 
                 if (targetStatus == "chat")
@@ -212,8 +218,17 @@ internal class ProxiedConnection
                     }
                 }
                 
-                // keep user title and banner in lobby
-                PresenceScrub.ScrubValorantPresence(presence);
+                if (targetStatus == ValorantLobbyStatus)
+                {
+                    // Retain only enough VALORANT presence to render lobby info,
+                    // then mask it in Riot Client with mock Runeterra away presence.
+                    PresenceScrub.ScrubValorantPresence(presence);
+                }
+                else
+                {
+                    // Standard offline/mobile behavior: publish no VALORANT presence.
+                    presence.Element("games")?.Element("valorant")?.Remove();
+                }
             }
 
             var sb = new StringBuilder();

--- a/Deceive/ProxiedConnection.cs
+++ b/Deceive/ProxiedConnection.cs
@@ -211,9 +211,9 @@ internal class ProxiedConnection
                             await SendFakePlayerPresenceAsync();
                     }
                 }
-
-                // Remove VALORANT presence
-                presence.Element("games")?.Element("valorant")?.Remove();
+                
+                // keep user title and banner in lobby
+                PresenceScrub.ScrubValorantPresence(presence);
             }
 
             var sb = new StringBuilder();


### PR DESCRIPTION
Added a presenceScrub util that keeps playerPresenceData from valorant. So that when user is in team lobby their banner and title still show normally. 